### PR TITLE
Perf: Proimse.any + AbortController

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -54,7 +54,7 @@ sw.addEventListener("fetch", event => {
       });
     }
 
-    const doFetch = fetchWithSignal(abortController ? abortController.signal : null);
+    const doFetch = fetchWithSignal(abortController ? abortController.signal : undefined);
     return async (...args: Parameters<F>) => {
       const response = await doFetch(...args);
       if (response) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "target": "es2019",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "strict": false
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
- Prefer `Promise.any` instead of home-baked promise race implementation.
  - Provide a light-weight `Promise.any` polyfill with ES2019 support
- Use `AbortController` to abort a fired request, to potentially save bandwidth of the server